### PR TITLE
runtime: Bold and underline highlighting in Man

### DIFF
--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -1,137 +1,211 @@
-let s:man_tag_depth = 0
-let s:man_sect_arg = ''
-let s:man_find_arg = '-w'
-
-try
-  if !has('win32') && $OSTYPE !~? 'cygwin\|linux' && system('uname -s') =~? 'SunOS' && system('uname -r') =~? '^5'
-    let s:man_sect_arg = '-s'
-    let s:man_find_arg = '-l'
-  endif
-catch /E145:/
-  " Ignore the error in restricted mode
-endtry
-
-" Load man page {page} from {section}
-"   call man#get_page([{section}, ]{page})
-function man#get_page(...) abort
-  let invoked_from_man = (&filetype ==# 'man')
-
-  if a:0 == 0
-    echoerr 'argument required'
+let s:man_cmd = 'man 2>/dev/null'
+" regex for valid extensions that manpages can have
+let s:man_extensions = '[glx]z\|bz2\|lzma\|Z'
+let s:man_tag_stack = []
+function! man#get_page(bang, editcmd, ...) abort
+  " fpage is a string like 'printf(2)'
+  if empty(a:000)
+    let fpage = expand('<cWORD>')
+    if empty(fpage)
+      call s:error("no WORD under cursor")
+      return
+    endif
+  elseif len(a:000) > 2
+    call s:error('too many arguments')
     return
-  elseif a:0 > 2
-    echoerr 'too many arguments'
-    return
+  elseif len(a:000) == 1
+    let fpage = a:000[0]
+  else
+    let fpage = a:000[1].'('.a:000[0].')'
   endif
 
-  let sect = get(a:000, 0)
-  let page = get(a:000, 1, sect)
-
-  let [page, sect] = s:parse_page_and_section(sect, page)
-
-  if !empty(sect) && s:find_page(sect, page) == 0
+  " if fpage is a path, no need to parse anything
+  if fpage =~# '\/'
+    let page = fpage
     let sect = ''
+  else
+    let [page, sect] = s:parse_page_and_section(fpage)
+    if empty(page)
+      call s:error('invalid manpage name '.fpage)
+      return
+    endif
+    let path = s:find_page(sect, page)
+    if empty(path)
+      call s:error("no manual entry for ".fpage)
+      return
+    elseif empty(sect)
+      let sect = s:parse_sect(path[0])
+    endif
   endif
 
-  if s:find_page(sect, page) == 0
-    echo 'No manual entry for '.page
-    return
+  call s:push_tag_stack()
+
+  if g:find_man_window != a:bang && &filetype !=# 'man'
+    let cmd = s:find_man(a:editcmd)
+  else
+    let cmd = a:editcmd
   endif
 
-  exec 'let s:man_tag_buf_'.s:man_tag_depth.' = '.bufnr('%')
-  exec 'let s:man_tag_lin_'.s:man_tag_depth.' = '.line('.')
-  exec 'let s:man_tag_col_'.s:man_tag_depth.' = '.col('.')
-  let s:man_tag_depth = s:man_tag_depth + 1
+  call s:read_page(sect, page, cmd)
+endfunction
 
-  let editcmd = 'edit'
-  " Use an existing 'man' window, else open a new one.
-  if &filetype !=# 'man'
+" move to previous position in the stack
+function! man#pop_tag_stack() abort
+  if !empty(s:man_tag_stack)
+    execute s:man_tag_stack[-1]['buf'].'b'
+    execute s:man_tag_stack[-1]['lin']
+    execute 'normal! '.s:man_tag_stack[-1]['col'].'|'
+    call remove(s:man_tag_stack, -1)
+  endif
+endfunction
+
+" save current position
+function! s:push_tag_stack() abort
+  let s:man_tag_stack = add(s:man_tag_stack, {
+        \ 'buf': bufnr('%'),
+        \ 'lin': line('.'),
+        \ 'col': col('.')
+        \ })
+endfunction
+
+" find the closest man window above/left
+function! s:find_man(cmd) abort
+  if winnr('$') > 1
     let thiswin = winnr()
-    wincmd b
-    if winnr() > 1
-      exec thiswin . 'wincmd w'
-      while 1
-        if &filetype ==# 'man'
-          break
-        endif
-        wincmd w
-        if thiswin == winnr()
-          break
-        endif
-      endwhile
-    endif
-
-    if &filetype !=# 'man'
-      let editcmd = 'tabnew'
-    endif
+    while 1
+      if &filetype ==# 'man'
+        return 'edit'
+      endif
+      wincmd w
+      if thiswin == winnr() | break | endif
+    endwhile
   endif
+  return a:cmd
+endfunction
 
-  silent exec editcmd.' man://'.page.(empty(sect)?'':'('.sect.')')
+" parses the sect/page out of 'page(sect)'
+function! s:parse_page_and_section(fpage) abort
+  let ret = split(a:fpage, '(')
+  if len(ret) == 2 && ret[1] =~# '^\f\+)\f*$'
+    let iret = split(ret[1], ')')
+    return [ret[0], iret[0]]
+  elseif len(ret) == 1
+    return [ret[0], '']
+  else
+    return ['', '']
+  endif
+endfunction
 
+" returns the path of a manpage
+function! s:find_page(sect, page) abort
+  return split(system(s:man_cmd.' -w '.a:sect.' '.a:page), '\n')
+endfunction
+
+" parses the section out of the path to a manpage
+function! s:parse_sect(path) abort
+  let tail = fnamemodify(a:path, ':t')
+  if fnamemodify(tail, ":e") =~# '\%('.s:man_extensions.'\)\n'
+    let tail = fnamemodify(tail, ':r')
+  endif
+  return substitute(tail, '\f\+\.\([^.]\+\)', '\1', '')
+endfunction
+
+function! s:read_page(sect, page, cmd)
+  silent execute a:cmd 'man://'.a:page.(empty(a:sect)?'':'('.a:sect.')')
   setlocal modifiable
-  silent keepjumps norm! 1G"_dG
-  if empty($MANWIDTH)
-    let $MANWIDTH = winwidth(0)
-  endif
-  silent exec 'r!/usr/bin/man '.s:cmd(sect, page).' | col -b'
-  " Remove blank lines from top and bottom.
+  " remove all the text, incase we already loaded the manpage before
+  silent keepjumps normal! gg"_dG
+  let $MANWIDTH = winwidth(0)-1
+  " read manpage into buffer
+  silent execute 'r!'.s:man_cmd.' '.a:sect.' '.a:page
+  " remove all those backspaces
+  silent! keepjumps %substitute,.,,g
+  " remove blank lines from top and bottom.
   while getline(1) =~# '^\s*$'
     silent keepjumps 1delete _
   endwhile
   while getline('$') =~# '^\s*$'
     silent keepjumps $delete _
   endwhile
-  setlocal nomodified
+  keepjumps normal! gg
   setlocal filetype=man
-
-  if invoked_from_man || editcmd ==# 'tabnew'
-    call s:set_window_local_options()
-  endif
 endfunction
 
-function s:set_window_local_options() abort
-  setlocal colorcolumn=0 foldcolumn=0 nonumber
-  setlocal nolist norelativenumber nofoldenable
+function! s:error(msg) abort
+  redraws!
+  echon "man: "
+  echohl ErrorMsg
+  echon a:msg
+  echohl None
 endfunction
 
-function man#pop_page() abort
-  if s:man_tag_depth > 0
-    let s:man_tag_depth = s:man_tag_depth - 1
-    exec "let s:man_tag_buf=s:man_tag_buf_".s:man_tag_depth
-    exec "let s:man_tag_lin=s:man_tag_lin_".s:man_tag_depth
-    exec "let s:man_tag_col=s:man_tag_col_".s:man_tag_depth
-    exec s:man_tag_buf."b"
-    exec s:man_tag_lin
-    exec "norm! ".s:man_tag_col."|"
-    exec "unlet s:man_tag_buf_".s:man_tag_depth
-    exec "unlet s:man_tag_lin_".s:man_tag_depth
-    exec "unlet s:man_tag_col_".s:man_tag_depth
-    unlet s:man_tag_buf s:man_tag_lin s:man_tag_col
-  endif
-endfunction
-
-" Expects a string like 'access' or 'access(2)'.
-function s:parse_page_and_section(sect, str) abort
-  try
-    let [page, sect] = matchlist(a:str, '\v\C([-.[:alnum:]_]+)%(\(([-.[:alnum:]_]+)\))?')[1:2]
-    if empty(sect)
-      let sect = a:sect
+function! man#Complete(ArgLead, CmdLine, CursorPos) abort
+  let args = split(a:CmdLine)
+  let l = len(args)
+  " if the cursor (|) is at ':Man printf(|' then
+  " make sure to display the section. See s:get_candidates
+  let fpage = 0
+  " if already completed a manpage, we return
+  if (l > 1 && args[1] =~# ')\f*$') || l > 3 || a:ArgLead =~# ')$'
+    return
+  elseif l == 3
+    " cursor (|) is at ':Man 3 printf |'
+    if empty(a:ArgLead)
+      return
     endif
-  catch
-    echoerr 'man.vim: failed to parse: "'.a:str.'"'
-  endtry
-
-  return [page, sect]
-endfunction
-
-function s:cmd(sect, page) abort
-  if !empty(a:sect)
-    return s:man_sect_arg.' '.a:sect.' '.a:page
+    let sect = args[1]
+    let page = args[2]
+  elseif l == 2
+    " cursor (|) is at ':Man 3 |'
+    if empty(a:ArgLead)
+      let page = ""
+      let sect = args[1]
+    elseif a:ArgLead =~# '^\f\+(\f*$'
+      " cursor (|) is at ':Man printf(|'
+      let tmp = split(a:ArgLead, '(')
+      let page = tmp[0]
+      let sect = substitute(get(tmp, 1, '*'), ')$', '', '').'*'
+      let fpage = 1
+    else
+      " cursor (|) is at ':Man printf
+      let page = args[1]
+      let sect = '*'
+    endif
+  else
+    let page = ''
+    let sect = '*'
   endif
-  return a:page
+  return s:get_candidates(page, sect, fpage)
 endfunction
 
-function s:find_page(sect, page) abort
-  let where = system('/usr/bin/man '.s:man_find_arg.' '.s:cmd(a:sect, a:page))
-  return (where =~# '^ */')
+function! s:get_candidates(page, sect, fpage) abort
+  let mandirs = s:MANDIRS()
+  let candidates = globpath(mandirs, "*/" . a:page . "*." . a:sect, 0, 1)
+  let find = '\(.\+\)\.\%('.s:man_extensions.'\)\@!\'
+  " if the page is a path, complete files
+  if a:sect ==# '*' && a:page =~# '\/'
+    "TODO why does this complete the last one automatically
+    let candidates = glob(a:page.'*', 0, 1)
+  else
+    " if the section is not empty and the cursor (|) is not at
+    " ':Man printf(|' then do not show sections.
+    if a:sect != '*' && !a:fpage
+      let find .= '%([^.]\+\).*'
+      let repl = '\1'
+    else
+      let find .= '([^.]\+\).*'
+      let repl = '\1(\2)'
+    endif
+    for i in range(len(candidates))
+      let candidates[i] = substitute((fnamemodify(candidates[i], ":t")), find, repl, "")
+    endfor
+  endif
+  return candidates
+endfunction
+
+function! s:MANDIRS() abort
+  " gets list of MANDIRS
+  let mandirs_list = split(system(s:man_cmd.' -w'), ':\|\n')
+  " removes duplicates and then joins by comma
+  return join(filter(mandirs_list, 'index(mandirs_list, v:val, v:key+1)==-1'), ',')
 endfunction

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -1,21 +1,42 @@
-let s:man_cmd = 'man 2>/dev/null'
+" Ensure Vim is not recursively invoked (man-db does this)
+" by removing MANPAGER from the environment
+" More info here http://comments.gmane.org/gmane.editors.vim.devel/29085
+if &shell =~# 'fish$'
+  let s:man_cmd = 'set -e MANPAGER; man ^/dev/null'
+else
+  let s:man_cmd = 'unset MANPAGER; man 2>/dev/null '
+endif
 " regex for valid extensions that manpages can have
 let s:man_extensions = '[glx]z\|bz2\|lzma\|Z'
-let s:man_tag_stack = []
+let s:man_sect_arg = ''
+let s:man_find_arg = '-w'
+let s:tag_stack = []
+
+try
+  if !has('win32') && $OSTYPE !~? 'cygwin\|linux' && system('uname -s') =~? 'SunOS' && system('uname -r') =~? '^5'
+    let s:man_sect_arg = '-s'
+    let s:man_find_arg = '-l'
+  endif
+catch /E145:/
+  " Ignore the error in restricted mode
+endtry
+
 function! man#get_page(bang, editcmd, ...) abort
-  " fpage is a string like 'printf(2)'
-  if empty(a:000)
+  " fpage is a string like 'printf(2)' or just 'printf'
+  if a:0 == 0
     let fpage = expand('<cWORD>')
     if empty(fpage)
-      call s:error("no WORD under cursor")
+      call s:error('no WORD under cursor')
       return
     endif
-  elseif len(a:000) > 2
+  elseif a:0 > 2
     call s:error('too many arguments')
     return
-  elseif len(a:000) == 1
+  elseif a:0 == 1
+    " only page
     let fpage = a:000[0]
   else
+    " page and sect
     let fpage = a:000[1].'('.a:000[0].')'
   endif
 
@@ -31,16 +52,16 @@ function! man#get_page(bang, editcmd, ...) abort
     endif
     let path = s:find_page(sect, page)
     if empty(path)
-      call s:error("no manual entry for ".fpage)
+      call s:error('no manual entry for '.fpage)
       return
-    elseif empty(sect)
+    else
       let sect = s:parse_sect(path[0])
     endif
   endif
 
-  call s:push_tag_stack()
+  call s:push_tag()
 
-  if g:find_man_window != a:bang && &filetype !=# 'man'
+  if g:man_find_window != a:bang && &filetype !=# 'man'
     let cmd = s:find_man(a:editcmd)
   else
     let cmd = a:editcmd
@@ -50,22 +71,21 @@ function! man#get_page(bang, editcmd, ...) abort
 endfunction
 
 " move to previous position in the stack
-function! man#pop_tag_stack() abort
-  if !empty(s:man_tag_stack)
-    execute s:man_tag_stack[-1]['buf'].'b'
-    execute s:man_tag_stack[-1]['lin']
-    execute 'normal! '.s:man_tag_stack[-1]['col'].'|'
-    call remove(s:man_tag_stack, -1)
+function! man#pop_tag() abort
+  if !empty(s:tag_stack)
+    let tag = remove(s:tag_stack, -1)
+    execute tag['buf'].'b'
+    call cursor(tag['lnum'], tag['col'])
   endif
 endfunction
 
 " save current position
-function! s:push_tag_stack() abort
-  let s:man_tag_stack = add(s:man_tag_stack, {
-        \ 'buf': bufnr('%'),
-        \ 'lin': line('.'),
-        \ 'col': col('.')
-        \ })
+function! s:push_tag() abort
+  let s:tag_stack += [{
+        \ 'buf':  bufnr('%'),
+        \ 'lnum': line('.'),
+        \ 'col':  col('.'),
+        \ }]
 endfunction
 
 " find the closest man window above/left
@@ -98,13 +118,13 @@ endfunction
 
 " returns the path of a manpage
 function! s:find_page(sect, page) abort
-  return split(system(s:man_cmd.' -w '.a:sect.' '.a:page), '\n')
+  return split(system(s:man_cmd.s:man_find_arg.' '.s:man_args(a:sect, a:page)), '\n')
 endfunction
 
 " parses the section out of the path to a manpage
 function! s:parse_sect(path) abort
   let tail = fnamemodify(a:path, ':t')
-  if fnamemodify(tail, ":e") =~# '\%('.s:man_extensions.'\)\n'
+  if fnamemodify(tail, ':e') =~# '\%('.s:man_extensions.'\)\n'
     let tail = fnamemodify(tail, ':r')
   endif
   return substitute(tail, '\f\+\.\([^.]\+\)', '\1', '')
@@ -114,12 +134,12 @@ function! s:read_page(sect, page, cmd)
   silent execute a:cmd 'man://'.a:page.(empty(a:sect)?'':'('.a:sect.')')
   setlocal modifiable
   " remove all the text, incase we already loaded the manpage before
-  silent keepjumps normal! gg"_dG
+  silent keepjumps %delete _
   let $MANWIDTH = winwidth(0)-1
   " read manpage into buffer
-  silent execute 'r!'.s:man_cmd.' '.a:sect.' '.a:page
+  silent execute 'r!'.s:man_cmd.s:man_args(a:sect, a:page)
   " remove all those backspaces
-  silent! keepjumps %substitute,.,,g
+  execute "silent! keepjumps %substitute,.\b,,g"
   " remove blank lines from top and bottom.
   while getline(1) =~# '^\s*$'
     silent keepjumps 1delete _
@@ -127,13 +147,20 @@ function! s:read_page(sect, page, cmd)
   while getline('$') =~# '^\s*$'
     silent keepjumps $delete _
   endwhile
-  keepjumps normal! gg
+  keepjumps 1
   setlocal filetype=man
 endfunction
 
+function s:man_args(sect, page) abort
+  if !empty(a:sect)
+    return s:man_sect_arg.' '.shellescape(a:sect).' '.shellescape(a:page)
+  endif
+  return shellescape(a:page)
+endfunction
+
 function! s:error(msg) abort
-  redraws!
-  echon "man: "
+  redrawstatus!
+  echon 'man: '
   echohl ErrorMsg
   echon a:msg
   echohl None
@@ -146,66 +173,64 @@ function! man#Complete(ArgLead, CmdLine, CursorPos) abort
   " make sure to display the section. See s:get_candidates
   let fpage = 0
   " if already completed a manpage, we return
-  if (l > 1 && args[1] =~# ')\f*$') || l > 3 || a:ArgLead =~# ')$'
+  if (l > 1 && args[1] =~# ')\f*$') || l > 3
     return
   elseif l == 3
-    " cursor (|) is at ':Man 3 printf |'
-    if empty(a:ArgLead)
+    " cursor (|) is at ':Man 3 printf |', or ':Man 3 printf(|'
+    if empty(a:ArgLead) || a:ArgLead =~# ')\|('
       return
     endif
     let sect = args[1]
-    let page = args[2]
+    let page = a:ArgLead
   elseif l == 2
     " cursor (|) is at ':Man 3 |'
     if empty(a:ArgLead)
-      let page = ""
+      let page = ''
       let sect = args[1]
     elseif a:ArgLead =~# '^\f\+(\f*$'
       " cursor (|) is at ':Man printf(|'
       let tmp = split(a:ArgLead, '(')
       let page = tmp[0]
-      let sect = substitute(get(tmp, 1, '*'), ')$', '', '').'*'
+      let sect = substitute(get(tmp, 1, ''), ')$', '', '')
       let fpage = 1
     else
-      " cursor (|) is at ':Man printf
-      let page = args[1]
-      let sect = '*'
+      " cursor (|) is at ':Man printf|'
+      let page = a:ArgLead
+      let sect = ''
     endif
   else
     let page = ''
-    let sect = '*'
+    let sect = ''
   endif
   return s:get_candidates(page, sect, fpage)
 endfunction
 
 function! s:get_candidates(page, sect, fpage) abort
   let mandirs = s:MANDIRS()
-  let candidates = globpath(mandirs, "*/" . a:page . "*." . a:sect, 0, 1)
+  let candidates = globpath(mandirs,'*/'.a:page.'*.'.a:sect.'*', 0, 1)
   let find = '\(.\+\)\.\%('.s:man_extensions.'\)\@!\'
   " if the page is a path, complete files
-  if a:sect ==# '*' && a:page =~# '\/'
+  if empty(a:sect) && a:page =~# '\/'
     "TODO why does this complete the last one automatically
     let candidates = glob(a:page.'*', 0, 1)
   else
     " if the section is not empty and the cursor (|) is not at
     " ':Man printf(|' then do not show sections.
-    if a:sect != '*' && !a:fpage
+    if !empty(a:sect) && !a:fpage
       let find .= '%([^.]\+\).*'
       let repl = '\1'
     else
       let find .= '([^.]\+\).*'
       let repl = '\1(\2)'
     endif
-    for i in range(len(candidates))
-      let candidates[i] = substitute((fnamemodify(candidates[i], ":t")), find, repl, "")
-    endfor
+    call map(candidates, 'substitute((fnamemodify(v:val, ":t")), find, repl, "")')
   endif
   return candidates
 endfunction
 
 function! s:MANDIRS() abort
   " gets list of MANDIRS
-  let mandirs_list = split(system(s:man_cmd.' -w'), ':\|\n')
+  let mandirs_list = split(system(s:man_cmd.s:man_find_arg), ':\|\n')
   " removes duplicates and then joins by comma
   return join(filter(mandirs_list, 'index(mandirs_list, v:val, v:key+1)==-1'), ',')
 endfunction

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -199,12 +199,16 @@ endfunction
 
 function! s:get_candidates(page, sect, fpage) abort
   let candidates = globpath(s:MANDIRS(),'*/'.a:page.'*.'.a:sect.'*', 0, 1)
-  let find = '\(.\+\)\.\%('.s:man_extensions.'\)\@!\'
+  " The extension of each candidate must either (be a:sect and not part of
+  " s:man_extensions) or (it must be part of s:man_extensions and the root of
+  " the file name's extension must be a:sect).
+  call filter(candidates, "(v:val =~# a:sect.'$' && v:val !~# s:man_extensions.'$' ) || (v:val =~# s:man_extensions.'$' && fnamemodify(v:val, ':r') =~# a:sect.'$')")
   " if the page is a path, complete files
   if empty(a:sect) && a:page =~# '\/'
     "TODO(nhooyr) why does this complete the last one automatically
     let candidates = glob(a:page.'*', 0, 1)
   else
+    let find = '\(.\+\)\.\%('.s:man_extensions.'\)\@!\'
     " if the section is not empty and the cursor (|) is not at
     " ':Man printf(|' then do not show sections.
     if !empty(a:sect) && !a:fpage

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -132,12 +132,11 @@ function! man#normalize_page()
   endwhile
 
   let view = winsaveview()
-  " Find ^H and format them.  Uses \255 (bullet) and \246 (broken pipe) as
-  " delimiters.
-  silent keepjumps %s/\%(\(.\)\b\1\)\+/\="\225".substitute(submatch(0),
-        \ '\(.\)\b\1', '\1', 'g')."\225"/ge
-  silent keepjumps %s/\%(_\b.\)\+/\="\246".substitute(submatch(0),
-        \ '_\b\(.\)', '\1', 'g')."\246"/ge
+  " Find ^H and format them.  Uses ^B for bold and ^U for underline.
+  silent keepjumps %s/\%(\(.\)\b\1\)\+/\=''.substitute(submatch(0),
+        \ '\(.\)\b\1', '\1', 'g').''/ge
+  silent keepjumps %s/\%(_\b.\)\+/\=''.substitute(submatch(0),
+        \ '_\b\(.\)', '\1', 'g').''/ge
   call histdel('search', -1)
   let @/ = histget('search', -1)
   call winrestview(view)

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -157,8 +157,8 @@ function! s:error(msg) abort
   echohl None
 endfunction
 
-function! man#complete(ArgLead, CmdLine, CursorPos) abort
-  let args = split(a:CmdLine)
+function! man#complete(arg_lead, cmd_line, cursor_pos) abort
+  let args = split(a:cmd_line)
   let l = len(args)
   " if the cursor (|) is at ':Man printf(|' then
   " make sure to display the section. See s:get_candidates
@@ -168,25 +168,25 @@ function! man#complete(ArgLead, CmdLine, CursorPos) abort
     return
   elseif l == 3
     " cursor (|) is at ':Man 3 printf |'
-    if empty(a:ArgLead)
+    if empty(a:arg_lead)
       return
     endif
     let sect = tolower(args[1])
-    let page = a:ArgLead
+    let page = a:arg_lead
   elseif l == 2
     " cursor (|) is at ':Man 3 |'
-    if empty(a:ArgLead)
+    if empty(a:arg_lead)
       let page = ''
       let sect = tolower(args[1])
-    elseif a:ArgLead =~# '^\f\+(\f*$'
+    elseif a:arg_lead =~# '^\f\+(\f*$'
       " cursor (|) is at ':Man printf(|'
-      let tmp = split(a:ArgLead, '(')
+      let tmp = split(a:arg_lead, '(')
       let page = tmp[0]
       let sect = tolower(get(tmp, 1, ''))
       let fpage = 1
     else
       " cursor (|) is at ':Man printf|'
-      let page = a:ArgLead
+      let page = a:arg_lead
       let sect = ''
     endif
   else
@@ -196,8 +196,8 @@ function! man#complete(ArgLead, CmdLine, CursorPos) abort
   return s:get_candidates(page, sect, fpage)
 endfunction
 
+
 function! s:init_mandirs() abort
-  " gets list of MANDIRS
   let mandirs_list = split(system(s:man_cmd.s:man_find_arg), ':\|\n')
   " removes duplicates and then join by comma
   let s:mandirs = join(filter(mandirs_list, 'index(mandirs_list, v:val, v:key+1)==-1'), ',')

--- a/runtime/autoload/man.vim
+++ b/runtime/autoload/man.vim
@@ -112,7 +112,7 @@ function! s:parse_page_and_sect_path(path) abort
 endfunction
 
 function! s:read_page(sect, page, cmd)
-  silent execute s:find_man(a:cmd) 'man://'.a:page.(s:empty_sect(a:sect)? '':'('.a:sect.')')
+  silent execute s:find_man(a:cmd) 'man://'.a:page.(s:empty_sect(a:sect)?'':'('.a:sect.')')
   setlocal modifiable
   " remove all the text, incase we already loaded the manpage before
   silent keepjumps %delete _

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -500,7 +500,7 @@ Options:
 		avoid that a Subject line with "Vim:" in it will cause an
 		error message.
 'textwidth'	is set to 72.  This is often recommended for e-mail.
-'formatoptions'  is set to break text lines and to repeat the comment leader
+'formatoptions'	is set to break text lines and to repeat the comment leader
 		in new lines, so that a leading ">" for quotes is repeated.
 		You can also format quoted text with |gq|.
 
@@ -512,37 +512,49 @@ Local mappings:
 
 MAN					*ft-man-plugin* *:Man* *man.vim*
 
-Displays a manual page in a nice way.  Also see the user manual
-|find-manpage|.
-
-To start using the ":Man" command before any manual page was loaded, source
-this script from your startup vimrc file: >
-
-	runtime ftplugin/man.vim
-
-Options:
-'iskeyword'	the '.' character is added to be able to use CTRL-] on the
-		manual page name.
+View manpages from the comfort of vim. Features include syntax highlighting,
+autocompletion, multilingual support, and manpage jumping.
+Also see |find-manpage|.
 
 Commands:
-Man {name}	Display the manual page for {name} in a window.
-Man {number} {name}
-		Display the manual page for {name} in a section {number}.
-
-Global mapping:
-<Leader>K	Displays the manual page for the word under the cursor.
+Man			Display the manual page for <cWORD> in a new tab.
+Man {name}		Display the manual page for {name} in a new tab.
+Man {sect} {name}	Same as above except specify the section.
+Man {name}({sect})	Alternate syntax to above.
 
 Local mappings:
-CTRL-]		Jump to the manual page for the word under the cursor.
-CTRL-T		Jump back to the previous manual page.
-q		Same as ":quit"
+=======
+CTRL-]			Jump to the manual page for the <cWORD> under the cursor.
+K			Same as CTRL-].
+CTRL-T			Jump back to the previous manual page.
+q			Close the window.
 
 To enable folding use this: >
-  	let g:ft_man_folding_enable = 1
+	let g:ft_man_folding_enable = 1
 If you do not like the default folding, use an autocommand to add your desired
 folding style instead.  For example: >
-        autocmd FileType man setlocal foldmethod=indent foldenable
+	autocmd FileType man setlocal foldmethod=indent foldenable
 
+Variables:
+g:man_find_window
+			If set, man will attempt to find the current man window
+			before opening a new one. A bang on the commands will
+			do the opposite of whatever this variable is set to.
+			Defaults to 1.
+g:man_synopsis
+			This only applies if you will be using languages other
+			than english.
+			In manpages of sections 2 and 3, there is sometimes some C
+			code under the heading SYNOPSIS. In english we can just match
+			SYNOPSIS and then can highlight all of the C code underneath.
+			However in other languages, SYNOPSIS is a different word, so how
+			are we to tell where the C code begins? This variable is a regex
+			that is used to match the SYNOPSIS heading.
+			Modify it for the language(s) you will be using.
+			Defaults to '\V\^SYNOPSIS\$'.
+g:no_man_maps
+			If set, no mappings are created in man buffers.
+			Defaults to 0.
 
 PDF							*ft-pdf-plugin*
 

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -516,14 +516,22 @@ View manpages from the comfort of vim. Features include syntax highlighting,
 autocompletion, multilingual support, and manpage jumping.
 Also see |find-manpage|.
 
+You can use neovim as a manpager by setting >
+
+     export MANPAGER="nvim -c 'set ft=man' -"
+
+
 Commands:
 Man			Display the manual page for <cWORD> in a new tab.
 Man {name}		Display the manual page for {name} in a new tab.
 Man {sect} {name}	Same as above except specify the section.
 Man {name}({sect})	Alternate syntax to above. Exists so that you can see
-			the section of the manpage you are completing
+			the section of the manpage you are completing.
 Man {path}		Open the manpage specified by path, if it's in the current
 			directory, specify the leading ./
+Global Mappings:
+<Plug>(Man)             Jump to the manual page for the <cWORD> under the
+                        cursor in a new tab.
 
 Local mappings:
 CTRL-]			Jump to the manual page for the <cWORD> under the cursor.

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -520,10 +520,12 @@ Commands:
 Man			Display the manual page for <cWORD> in a new tab.
 Man {name}		Display the manual page for {name} in a new tab.
 Man {sect} {name}	Same as above except specify the section.
-Man {name}({sect})	Alternate syntax to above.
+Man {name}({sect})	Alternate syntax to above. Exists so that you can see
+			the section of the manpage you are completing
+Man {path}		Open the manpage specified by path, if it's in the current
+			directory, specify the leading ./
 
 Local mappings:
-=======
 CTRL-]			Jump to the manual page for the <cWORD> under the cursor.
 K			Same as CTRL-].
 CTRL-T			Jump back to the previous manual page.
@@ -541,17 +543,6 @@ g:man_find_window
 			before opening a new one. A bang on the commands will
 			do the opposite of whatever this variable is set to.
 			Defaults to 1.
-g:man_synopsis
-			This only applies if you will be using languages other
-			than english.
-			In manpages of sections 2 and 3, there is sometimes some C
-			code under the heading SYNOPSIS. In english we can just match
-			SYNOPSIS and then can highlight all of the C code underneath.
-			However in other languages, SYNOPSIS is a different word, so how
-			are we to tell where the C code begins? This variable is a regex
-			that is used to match the SYNOPSIS heading.
-			Modify it for the language(s) you will be using.
-			Defaults to '\V\^SYNOPSIS\$'.
 g:no_man_maps
 			If set, no mappings are created in man buffers.
 			Defaults to 0.

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -531,21 +531,21 @@ K			Same as CTRL-].
 CTRL-T			Jump back to the previous manual page.
 q			Close the window.
 
-To enable folding use this: >
-	let g:ft_man_folding_enable = 1
-If you do not like the default folding, use an autocommand to add your desired
-folding style instead.  For example: >
-	autocmd FileType man setlocal foldmethod=indent foldenable
-
 Variables:
 g:man_find_window
 			If set, man will attempt to find the current man window
-			before opening a new one. A bang on the commands will
-			do the opposite of whatever this variable is set to.
-			Defaults to 1.
+			before opening a new one. Defaults to 1.
 g:no_man_maps
 			If set, no mappings are created in man buffers.
 			Defaults to 0.
+
+g:ft_man_folding_enable
+                        If set, manpages are folded with foldmethod=indent and
+                        foldnestmax=1.
+
+If you do not like the default folding, use an autcommand to add your desired
+folding style instead. For example: >
+          autocmd FileType man setlocal foldmethod=indent foldenable
 
 PDF							*ft-pdf-plugin*
 

--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -513,13 +513,12 @@ Local mappings:
 MAN					*ft-man-plugin* *:Man* *man.vim*
 
 View manpages from the comfort of vim. Features include syntax highlighting,
-autocompletion, multilingual support, and manpage jumping.
+smart autocompletion, multilingual support, and manpage jumping.
 Also see |find-manpage|.
 
 You can use neovim as a manpager by setting >
 
      export MANPAGER="nvim -c 'set ft=man' -"
-
 
 Commands:
 Man			Display the manual page for <cWORD> in a new tab.
@@ -531,10 +530,12 @@ Man {path}		Open the manpage specified by path, if it's in the current
 			directory, specify the leading ./
 Global Mappings:
 <Plug>(Man)             Jump to the manual page for the <cWORD> under the
-                        cursor in a new tab.
+                        cursor in a new tab. Takes a count as the manpage
+			section.
 
 Local mappings:
-CTRL-]			Jump to the manual page for the <cWORD> under the cursor.
+CTRL-]			Jump to the manual page for the <cWORD> under the cursor. Takes a count
+                        as the manpage section.
 K			Same as CTRL-].
 CTRL-T			Jump back to the previous manual page.
 q			Close the window.

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -3,6 +3,11 @@ if exists('b:did_ftplugin')
 endif
 let b:did_ftplugin = 1
 
+if expand('%') !~# '^man:\/\/'
+  call man#normalize_page()
+  silent execute 'file '.'man://'.tolower(substitute(getline(1), '^\(\S\+\).*$', '\1', 0))
+endif
+
 setlocal buftype=nofile
 setlocal noswapfile
 setlocal nofoldenable
@@ -18,16 +23,17 @@ setlocal shiftwidth=8
 setlocal nolist
 setlocal foldcolumn=0
 setlocal colorcolumn=0
+setlocal keywordprg=:Man
 
 if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
-  nnoremap <silent> <buffer> <C-]>    :call man#get_page(g:man_find_window, 'edit')<CR>
-  nmap     <silent> <buffer> <K>      <C-]>
+  nnoremap <silent> <buffer> <C-]> K
   nnoremap <silent> <buffer> <C-t>    :call man#pop_tag()<CR>
-  nnoremap <silent> <nowait><buffer>  q <C-W>c
+  nnoremap <silent> <nowait><buffer>  <C-W>c
 endif
 
 if exists('g:ft_man_folding_enable') && (g:ft_man_folding_enable == 1)
   setlocal foldmethod=indent foldnestmax=1 foldenable
 endif
 
+let b:undo_ftplugin = ''
 " vim: set sw=2:

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -1,41 +1,32 @@
-" Vim filetype plugin file
-" Language:	man
-" Maintainer:	SungHyun Nam <goweol@gmail.com>
-
-if has('vim_starting') && &filetype !=# 'man'
-  finish
-endif
-
-" Only do this when not done yet for this buffer
 if exists('b:did_ftplugin')
   finish
 endif
 let b:did_ftplugin = 1
 
-" Ensure Vim is not recursively invoked (man-db does this)
-" when doing ctrl-[ on a man page reference.
-if exists('$MANPAGER')
-  let $MANPAGER = ''
-endif
-
-setlocal iskeyword+=\.,-,(,)
-
-setlocal buftype=nofile noswapfile
-setlocal nomodifiable readonly bufhidden=hide nobuflisted tabstop=8
+setlocal buftype=nofile
+setlocal noswapfile
+setlocal nofoldenable
+setlocal bufhidden=hide
+setlocal nobuflisted
+setlocal nomodified
+setlocal readonly
+setlocal nomodifiable
+setlocal noexpandtab
+setlocal tabstop=8
+setlocal softtabstop=8
+setlocal shiftwidth=8
+setlocal nolist
+setlocal foldcolumn=0
+setlocal colorcolumn=0
 
 if !exists("g:no_plugin_maps") && !exists("g:no_man_maps")
-  nnoremap <silent> <buffer> <C-]>    :call man#get_page(v:count, expand('<cword>'))<CR>
-  nnoremap <silent> <buffer> <C-T>    :call man#pop_page()<CR>
-  nnoremap <silent> <nowait><buffer>  q <C-W>c
-  if &keywordprg !=# ':Man'
-    nnoremap <silent> <buffer> K      :call man#get_page(v:count, expand('<cword>'))<CR>
-  endif
+  nnoremap <silent> <buffer> <C-]>    :call man#get_page(g:find_man_window, 'edit')<CR>
+  nnoremap <silent> <buffer> <C-t>    :call man#pop_tag_stack()<CR>
+  nnoremap <silent> <buffer> q :q<CR>
 endif
 
 if exists('g:ft_man_folding_enable') && (g:ft_man_folding_enable == 1)
   setlocal foldmethod=indent foldnestmax=1 foldenable
 endif
-
-let b:undo_ftplugin = 'setlocal iskeyword<'
 
 " vim: set sw=2:

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -5,7 +5,7 @@ let b:did_ftplugin = 1
 
 if expand('%') !~# '^man:\/\/'
   call man#normalize_page()
-  silent execute 'file '.'man://'.tolower(substitute(getline(1), '^\(\S\+\).*$', '\1', 0))
+  silent execute 'file '.'man://'.tolower(matchstr(getline(1), '^\S\+'))
 endif
 
 setlocal buftype=nofile

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -19,10 +19,11 @@ setlocal nolist
 setlocal foldcolumn=0
 setlocal colorcolumn=0
 
-if !exists("g:no_plugin_maps") && !exists("g:no_man_maps")
-  nnoremap <silent> <buffer> <C-]>    :call man#get_page(g:find_man_window, 'edit')<CR>
-  nnoremap <silent> <buffer> <C-t>    :call man#pop_tag_stack()<CR>
-  nnoremap <silent> <buffer> q :q<CR>
+if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
+  nnoremap <silent> <buffer> <C-]>    :call man#get_page(g:man_find_window, 'edit')<CR>
+  nmap     <silent> <buffer> <K>      <C-]>
+  nnoremap <silent> <buffer> <C-t>    :call man#pop_tag()<CR>
+  nnoremap <silent> <nowait><buffer>  q <C-W>c
 endif
 
 if exists('g:ft_man_folding_enable') && (g:ft_man_folding_enable == 1)

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -26,9 +26,9 @@ setlocal colorcolumn=0
 setlocal keywordprg=:Man
 
 if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
-  nnoremap <silent> <buffer> <C-]> K
-  nnoremap <silent> <buffer> <C-t>    :call man#pop_tag()<CR>
-  nnoremap <silent> <nowait><buffer>  <C-W>c
+  nnoremap <silent> <buffer>          <C-]>    K
+  nnoremap <silent> <buffer>          <C-t>    :call man#pop_tag()<CR>
+  nnoremap <silent> <buffer> <nowait> q        <C-W>c
 endif
 
 if exists('g:ft_man_folding_enable') && (g:ft_man_folding_enable == 1)

--- a/runtime/plugin/man.vim
+++ b/runtime/plugin/man.vim
@@ -3,19 +3,13 @@ if exists('g:loaded_man')
 endif
 let g:loaded_man = 1
 
-if !exists("g:find_man_window")
-  let g:find_man_window = 1
+if !exists('g:man_find_window')
+  let g:man_find_window = 1
 endif
 
 if !exists('g:man_synopsis')
-  let g:man_synopsis = 'SYNOPSIS'
+  let g:man_synopsis = '\V\^SYNOPSIS\$'
 endif
 
 command! -bang -complete=customlist,man#Complete -nargs=* Man call
-      \ man#get_page(<bang>0, 'edit', <f-args>)
-command! -bang -complete=customlist,man#Complete -nargs=* Sman call
-      \ man#get_page(<bang>0, 'split', <f-args>)
-command! -bang -complete=customlist,man#Complete -nargs=* Vman call
-      \ man#get_page(<bang>0, 'vsplit', <f-args>)
-command! -bang -complete=customlist,man#Complete -nargs=* Tman call
-      \ man#get_page(<bang>0, 'tabe', <f-args>)
+      \ man#get_page(<bang>0, (tabpagenr()-1).'tabnew', <f-args>)

--- a/runtime/plugin/man.vim
+++ b/runtime/plugin/man.vim
@@ -3,13 +3,8 @@ if exists('g:loaded_man')
 endif
 let g:loaded_man = 1
 
-if !exists('g:man_find_window')
-  let g:man_find_window = 1
-endif
-
-if !exists('g:man_synopsis')
-  let g:man_synopsis = '\V\^SYNOPSIS\$'
-endif
+let g:neoman_find_window =
+      \ get( g:, 'neoman_find_window', 1 )
 
 command! -bang -complete=customlist,man#Complete -nargs=* Man call
       \ man#get_page(<bang>0, (tabpagenr()-1).'tabnew', <f-args>)

--- a/runtime/plugin/man.vim
+++ b/runtime/plugin/man.vim
@@ -3,8 +3,8 @@ if exists('g:loaded_man')
 endif
 let g:loaded_man = 1
 
-let g:neoman_find_window =
-      \ get( g:, 'neoman_find_window', 1 )
+let g:man_find_window =
+      \ get( g:, 'man_find_window', 1 )
 
-command! -bang -complete=customlist,man#Complete -nargs=* Man call
-      \ man#get_page(<bang>0, (tabpagenr()-1).'tabnew', <f-args>)
+command! -complete=customlist,man#Complete -nargs=* Man call
+      \ man#get_page((tabpagenr()-1).'tabnew', <f-args>)

--- a/runtime/plugin/man.vim
+++ b/runtime/plugin/man.vim
@@ -3,8 +3,9 @@ if exists('g:loaded_man')
 endif
 let g:loaded_man = 1
 
-let g:man_find_window =
-      \ get( g:, 'man_find_window', 1 )
+let g:man_find_window = get(g:, 'man_find_window', 1 )
 
-command! -complete=customlist,man#Complete -nargs=* Man call
-      \ man#get_page((tabpagenr()-1).'tabnew', <f-args>)
+command! -count=10 -complete=customlist,man#complete -nargs=* Man call
+      \ man#get_page(<count>, (tabpagenr()-1).'tabnew', <f-args>)
+
+nnoremap <silent> <Plug>(Man) :<C-u>call man#get_page(v:count, (tabpagenr()-1).'tabnew', expand('<cWORD>'))<CR>

--- a/runtime/plugin/man.vim
+++ b/runtime/plugin/man.vim
@@ -1,6 +1,21 @@
-if get(g:, 'loaded_man', 0)
+if exists('g:loaded_man')
   finish
 endif
 let g:loaded_man = 1
 
-command! -count=0 -nargs=+ Man call man#get_page(<count>, <f-args>)
+if !exists("g:find_man_window")
+  let g:find_man_window = 1
+endif
+
+if !exists('g:man_synopsis')
+  let g:man_synopsis = 'SYNOPSIS'
+endif
+
+command! -bang -complete=customlist,man#Complete -nargs=* Man call
+      \ man#get_page(<bang>0, 'edit', <f-args>)
+command! -bang -complete=customlist,man#Complete -nargs=* Sman call
+      \ man#get_page(<bang>0, 'split', <f-args>)
+command! -bang -complete=customlist,man#Complete -nargs=* Vman call
+      \ man#get_page(<bang>0, 'vsplit', <f-args>)
+command! -bang -complete=customlist,man#Complete -nargs=* Tman call
+      \ man#get_page(<bang>0, 'tabe', <f-args>)

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -6,8 +6,8 @@ syntax case  ignore
 syntax match manReference       '\f\+(\%([0-8][a-z]\=\|n\))'
 syntax match manTitle           '^\%1l\S\+\%((\%([0-8][a-z]\=\|n\))\)\=.*$'
 syntax match manSubHeading      '^\s\{3\}\%(\S.*\)\=\S$'
-syntax match manOptionDesc      '^\s\+[+-][a-z0-9]\S*'
-syntax match manLongOptionDesc  '^\s\+--[a-z0-9]\S*'
+syntax match manOptionDesc      '^\s\+[+-]\S\+'
+syntax match manLongOptionDesc  '^\s\+--\S\+'
 " prevent manSectionHeading from matching last line
 execute 'syntax match manSectionHeading  "^\%(\%>1l\%<'.line('$').'l\)\%(\S.*\)\=\S$"'
 

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -1,16 +1,15 @@
-if exists("b:current_syntax")
+if exists('b:current_syntax')
   finish
 endif
 
 syntax case  ignore
-syntax match manReference       "\f\+(\%([0-8][a-z]\=\|n\))"
-syntax match manTitle           "^\%1l\S\+\%((\%([0-8][a-z]\=\|n\))\)\=.*$"
-syntax match manSubHeading      "^\s\{3\}\%(\S.*\)\=\S$"
-syntax match manOptionDesc      "^\s\+[+-][a-z0-9]\S*"
-syntax match manLongOptionDesc  "^\s\+--[a-z0-9]\S*"
+syntax match manReference       '\f\+(\%([0-8][a-z]\=\|n\))'
+syntax match manTitle           '^\%1l\S\+\%((\%([0-8][a-z]\=\|n\))\)\=.*$'
+syntax match manSubHeading      '^\s\{3\}\%(\S.*\)\=\S$'
+syntax match manOptionDesc      '^\s\+[+-][a-z0-9]\S*'
+syntax match manLongOptionDesc  '^\s\+--[a-z0-9]\S*'
 " prevent manSectionHeading from matching last line
-let s:l = line('$')
-execute 'syntax match manSectionHeading  "^\%(\%>1l\%<'.s:l.'l\)\%(\S.*\)\=\S$"'
+execute 'syntax match manSectionHeading  "^\%(\%>1l\%<'.line('$').'l\)\%(\S.*\)\=\S$"'
 
 highlight default link manTitle          Title
 highlight default link manSectionHeading Statement
@@ -19,16 +18,11 @@ highlight default link manLongOptionDesc Constant
 highlight default link manReference      PreProc
 highlight default link manSubHeading     Function
 
-if getline(1) =~# '^\f\+([23])'
-  syntax include @cCode syntax/c.vim
-  " skip first heading
-  keepjumps call search('^\%(\S.*\)\=\S$')
-  " get second heading, aka the synopsis heading
-  let l = escape(getline(search('^\%(\S.*\)\=\S$', 'n')), '\')
-  keepjumps normal! gg
-  syntax match manCFuncDefinition display "\<\h\w*\>\s*("me=e-1 contained
-  execute 'syntax region manSynopsis start="\V\^'.l.'\$"hs=s+8 end="^\%(\S.*\)\=\S$"me=e-12 keepend contains=manSectionHeading,@cCode,manCFuncDefinition'
+if getline(1) =~# '^\f\+([23][a-zA-Z]\=)'
+  syntax include @cCode $VIMRUNTIME/syntax/c.vim
+  syntax match manCFuncDefinition display '\<\h\w*\>\s*('me=e-1 contained
+  execute "syntax region manSynopsis start='".g:man_synopsis."'".'hs=s+8 end="^\%(\S.*\)\=\S$"me=e-12 keepend contains=manSectionHeading,@cCode,manCFuncDefinition'
   highlight default link manCFuncDefinition Function
 endif
 
-let b:current_syntax = "man"
+let b:current_syntax = 'man'

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -11,8 +11,13 @@ syntax match manTitle           '^\%1l\S\+\%((\%([0-8][a-z]\=\|n\))\)\=.*$'
 syntax match manSubHeading      '^\s\{3\}\%(\S.*\)\=\S$'
 syntax match manOptionDesc      '^\s\+[+-]\S\+'
 syntax match manLongOptionDesc  '^\s\+--\S\+'
+syntax match manBold            '\%o225\%(\%o225\@!.\)\{-}\%o225' containedin=TOP contains=manBoldDelim
+syntax match manUnderline       '\%o246\%(\%o246\@!.\)\{-}\%o246' containedin=TOP contains=manUnderlineDelim
+syntax match manBoldDelim       '\%o225' contained conceal
+syntax match manUnderlineDelim  '\%o246' contained conceal
+
 " prevent manSectionHeading from matching last line
-execute 'syntax match manSectionHeading  "^\%(\%>1l\%<'.line('$').'l\)\%(\S.*\)\=\S$"'
+execute 'syntax match manSectionHeading  "^\%(\%>1l\%<'.line('$').'l\)\%(\S.*\)\=\S$" contains=manBoldDelim'
 
 highlight default link manTitle          Title
 highlight default link manSectionHeading Statement
@@ -20,6 +25,9 @@ highlight default link manOptionDesc     Constant
 highlight default link manLongOptionDesc Constant
 highlight default link manReference      PreProc
 highlight default link manSubHeading     Function
+highlight default link manBold           Keyword
+highlight default manBold cterm=bold gui=bold
+highlight default manUnderline cterm=underline gui=underline
 
 if getline(1) =~# '^\f\+([23][a-zA-Z]\=)'
   syntax include @cCode $VIMRUNTIME/syntax/c.vim

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -1,3 +1,6 @@
+" TODO(nhooyr) use backspaced text for better syntax highlighting.
+" see https://github.com/neovim/neovim/pull/4449#issuecomment-234696194
+
 if exists('b:current_syntax')
   finish
 endif

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -11,10 +11,10 @@ syntax match manTitle           '^\%1l\S\+\%((\%([0-8][a-z]\=\|n\))\)\=.*$'
 syntax match manSubHeading      '^\s\{3\}\%(\S.*\)\=\S$'
 syntax match manOptionDesc      '^\s\+[+-]\S\+'
 syntax match manLongOptionDesc  '^\s\+--\S\+'
-syntax match manBold            '\%o225\%(\%o225\@!.\)\{-}\%o225' containedin=TOP contains=manBoldDelim
-syntax match manUnderline       '\%o246\%(\%o246\@!.\)\{-}\%o246' containedin=TOP contains=manUnderlineDelim
-syntax match manBoldDelim       '\%o225' contained conceal
-syntax match manUnderlineDelim  '\%o246' contained conceal
+syntax match manBold            '\%(\@!.\)\{-}' containedin=TOP contains=manBoldDelim
+syntax match manUnderline       '\%(\@!.\)\{-}' containedin=TOP contains=manUnderlineDelim
+syntax match manBoldDelim       '' contained conceal
+syntax match manUnderlineDelim  '' contained conceal
 
 " prevent manSectionHeading from matching last line
 execute 'syntax match manSectionHeading  "^\%(\%>1l\%<'.line('$').'l\)\%(\S.*\)\=\S$" contains=manBoldDelim'

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -21,7 +21,13 @@ highlight default link manSubHeading     Function
 if getline(1) =~# '^\f\+([23][a-zA-Z]\=)'
   syntax include @cCode $VIMRUNTIME/syntax/c.vim
   syntax match manCFuncDefinition display '\<\h\w*\>\s*('me=e-1 contained
-  execute "syntax region manSynopsis start='".g:man_synopsis."'".'hs=s+8 end="^\%(\S.*\)\=\S$"me=e-12 keepend contains=manSectionHeading,@cCode,manCFuncDefinition'
+  syntax region manSynopsis start='\V\^\%(
+        \SYNOPSIS\|
+        \SYNTAX\|
+        \SINTASSI\|
+        \SKŁADNIA\|
+        \СИНТАКСИС\|
+        \書式\)\$'hs=s+8 end='^\%(\S.*\)\=\S$'me=e-12 keepend contains=manSectionHeading,@cCode,manCFuncDefinition
   highlight default link manCFuncDefinition Function
 endif
 

--- a/runtime/syntax/man.vim
+++ b/runtime/syntax/man.vim
@@ -1,67 +1,34 @@
-" Vim syntax file
-" Language:	Man page
-" Maintainer:	SungHyun Nam <goweol@gmail.com>
-" Previous Maintainer:	Gautam H. Mudunuri <gmudunur@informatica.com>
-" Version Info:
-" Last Change:	2015 Nov 24
-
-" Additional highlighting by Johannes Tanzler <johannes.tanzler@aon.at>:
-"	* manSubHeading
-"	* manSynopsis (only for sections 2 and 3)
-
-" For version 5.x: Clear all syntax items
-" For version 6.x: Quit when a syntax file was already loaded
-if version < 600
-  syntax clear
-elseif exists("b:current_syntax")
+if exists("b:current_syntax")
   finish
 endif
 
-" Get the CTRL-H syntax to handle backspaced text
-if version >= 600
-  runtime! syntax/ctrlh.vim
-else
-  source <sfile>:p:h/ctrlh.vim
-endif
+syntax case  ignore
+syntax match manReference       "\f\+(\%([0-8][a-z]\=\|n\))"
+syntax match manTitle           "^\%1l\S\+\%((\%([0-8][a-z]\=\|n\))\)\=.*$"
+syntax match manSubHeading      "^\s\{3\}\%(\S.*\)\=\S$"
+syntax match manOptionDesc      "^\s\+[+-][a-z0-9]\S*"
+syntax match manLongOptionDesc  "^\s\+--[a-z0-9]\S*"
+" prevent manSectionHeading from matching last line
+let s:l = line('$')
+execute 'syntax match manSectionHeading  "^\%(\%>1l\%<'.s:l.'l\)\%(\S.*\)\=\S$"'
 
-syn case ignore
-syn match  manReference       "\f\+([1-9][a-z]\=)"
-syn match  manTitle	      "^\f\+([0-9]\+[a-z]\=).*"
-syn match  manSectionHeading  "^[a-z][a-z -]*[a-z]$"
-syn match  manSubHeading      "^\s\{3\}[a-z][a-z -]*[a-z]$"
-syn match  manOptionDesc      "^\s*[+-][a-z0-9]\S*"
-syn match  manLongOptionDesc  "^\s*--[a-z0-9-]\S*"
-" syn match  manHistory		"^[a-z].*last change.*$"
+highlight default link manTitle          Title
+highlight default link manSectionHeading Statement
+highlight default link manOptionDesc     Constant
+highlight default link manLongOptionDesc Constant
+highlight default link manReference      PreProc
+highlight default link manSubHeading     Function
 
-if getline(1) =~ '^[a-zA-Z_]\+([23])'
-  syntax include @cCode <sfile>:p:h/c.vim
-  syn match manCFuncDefinition  display "\<\h\w*\>\s*("me=e-1 contained
-  syn region manSynopsis start="^SYNOPSIS"hs=s+8 end="^\u\+\s*$"me=e-12 keepend contains=manSectionHeading,@cCode,manCFuncDefinition
-endif
-
-
-" Define the default highlighting.
-" For version 5.7 and earlier: only when not done already
-" For version 5.8 and later: only when an item doesn't have highlighting yet
-if version >= 508 || !exists("did_man_syn_inits")
-  if version < 508
-    let did_man_syn_inits = 1
-    command -nargs=+ HiLink hi link <args>
-  else
-    command -nargs=+ HiLink hi def link <args>
-  endif
-
-  HiLink manTitle	    Title
-  HiLink manSectionHeading  Statement
-  HiLink manOptionDesc	    Constant
-  HiLink manLongOptionDesc  Constant
-  HiLink manReference	    PreProc
-  HiLink manSubHeading      Function
-  HiLink manCFuncDefinition Function
-
-  delcommand HiLink
+if getline(1) =~# '^\f\+([23])'
+  syntax include @cCode syntax/c.vim
+  " skip first heading
+  keepjumps call search('^\%(\S.*\)\=\S$')
+  " get second heading, aka the synopsis heading
+  let l = escape(getline(search('^\%(\S.*\)\=\S$', 'n')), '\')
+  keepjumps normal! gg
+  syntax match manCFuncDefinition display "\<\h\w*\>\s*("me=e-1 contained
+  execute 'syntax region manSynopsis start="\V\^'.l.'\$"hs=s+8 end="^\%(\S.*\)\=\S$"me=e-12 keepend contains=manSectionHeading,@cCode,manCFuncDefinition'
+  highlight default link manCFuncDefinition Function
 endif
 
 let b:current_syntax = "man"
-
-" vim:ts=8 sts=2 sw=2:


### PR DESCRIPTION
This PR is just a proof-of-concept and has no expectation of being merged.  I'm leaving it here so you have some reference for when you feel you're in a good place to deal with aesthetics.

It needs a little work particularly with the syntax groups for command line flags.  Some man pages bold them while others don't.  For the ones that do bold them, the highlighting is overridden which leads to inconsistency with color.